### PR TITLE
Print correct currmovenumber starting with 1

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -237,17 +237,17 @@ int Search::absearch(int depth, int alpha, int beta, int ply, bool null) {
 
     for (int i = 0; i < ml.size; i++) {
         Move move = ml.list[i];
-
-        if (RootNode && elapsed() > 10000 && !stopped) {
-            std::cout << "info depth " << depth << " currmove " << board.printMove(move) << " currmovenumber " << madeMoves << "\n";
-        }
-        
         bool capture = board.pieceAtB(move.to) != None;
 
         if (!capture) quietMoves++;
 
         nodes++;
         madeMoves++;
+
+        if (RootNode && elapsed() > 10000 && !stopped) {
+            std::cout << "info depth " << depth << " currmove " << board.printMove(move) << " currmovenumber " << madeMoves << "\n";
+        }
+        
         board.makeMove(move);
 
         U64 nodeCount = nodes;


### PR DESCRIPTION
by moving the output after the increment of the madeMoves variable.
No functional change.