### PR TITLE
tune search constants

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -132,13 +132,13 @@ Score Search::absearch(int depth, Score alpha, Score beta, Stack *ss, ThreadData
     // Razoring
     if (!PvNode
         && depth < 2
-        && staticEval + 240 < alpha
+        && staticEval + 102 < alpha
         && !inCheck)
         return qsearch(15, alpha, beta, ss->ply, td);
 
     // Reverse futility pruning
     if (std::abs(beta) < VALUE_MATE_IN_PLY && !inCheck && !PvNode) {
-        if (depth < 7 && staticEval - 150 * depth + 100 * improving >= beta) return beta;
+        if (depth < 7 && staticEval - 67 * depth + 76 * improving >= beta) return beta;
     }
 
     // Null move pruning
@@ -147,7 +147,7 @@ Score Search::absearch(int depth, Score alpha, Score beta, Stack *ss, ThreadData
         && depth >= 3 && !inCheck
         && staticEval >= beta) 
     {
-        int r = 5 + depth / 5 + std::min(3, (staticEval - beta) / 256);
+        int r = 5 + depth / 5 + std::min(3, (staticEval - beta) / 214);
         td->board.makeNullMove();
         (ss)->currentmove = NULLMOVE;
         Score score = -absearch(depth - r, -beta, -beta + 1, ss+1, td);
@@ -201,12 +201,12 @@ Score Search::absearch(int depth, Score alpha, Score beta, Stack *ss, ThreadData
                 && !PvNode
                 && !move.promoted()
                 && depth <= 4
-                && quietMoves.size > (4 + depth * depth))
+                && quietMoves.size > (3 + depth * depth))
                 continue;
 
             // See pruning
-            if (depth < 6 
-                && !see(move, -(depth * 100), td->board))
+            if (depth < 5
+                && !see(move, -(depth * 146), td->board))
                 continue;
         }
 


### PR DESCRIPTION
This is a big search tune done with chess-tuning-tools and 11 parameters (which is insane!). 
The first 130 iterations were done by @TheBlackPlague (thanks again!), with rounds set to 128 and tc of 5+0.05 each iteration was taking about ~80 seconds on a 128thread (limited to 64 threads because of cutechess) machine! 
After very promising first results I continued with the tuning for another 60 iterations each taking ~400 seconds with 10 threads. There might be soom room left for further improvements in the future. 

A big thanks goes to @kiudee for his amazing tuner, chess-tuning-tools.

    ELO   | 52.94 +- 16.69 (95%)
    SPRT  | 4.0+0.04s Threads=1 Hash=8MB
    LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
    GAMES | N: 992 W: 365 L: 215 D: 412

The new values also gain at LTC.

Bench: 2909386