### PR TITLE
initialise TT to zero

### DIFF
--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -28,12 +28,7 @@ int main(int argc, char** argv) {
     signal(SIGINT, signal_callback_handler);
     
     // Initialize TT
-    TEntry* oldbuffer;
-    if ((TTable = (TEntry*)malloc(TT_SIZE * sizeof(TEntry))) == NULL) 
-    {
-        std::cout << "Error: Could not allocate memory for TT" << std::endl;
-        exit(1);
-    }
+    allocate_tt();
 
     // Initialize NNUE
     // This either loads the weights from a file or makes use of the weights in the binary file that it was compiled with.
@@ -97,14 +92,7 @@ int main(int argc, char** argv) {
             if (option == "Hash")
             {
                 U64 elements = (static_cast<unsigned long long>(std::stoi(value)) * 1000000) / sizeof(TEntry);
-                oldbuffer = TTable;
-                if ((TTable = (TEntry*)realloc(TTable, elements * sizeof(TEntry))) == NULL)
-                {
-                    std::cout << "Error: Could not allocate memory for TT" << std::endl;
-                    free(oldbuffer);
-                    exit(1);
-                }
-                TT_SIZE = elements;  
+                reallocate_tt(elements);
             }
             else if (option == "EvalFile")
             {
@@ -299,4 +287,28 @@ void stop_threads()
             th.join();
     }
     searcher.threads.clear();    
+}
+
+void allocate_tt()
+{
+    if ((TTable = (TEntry*)malloc(TT_SIZE * sizeof(TEntry))) == NULL) 
+    {
+        std::cout << "Error: Could not allocate memory for TT" << std::endl;
+        exit(1);
+    }
+    std::memset(TTable, 0, TT_SIZE * sizeof(TEntry));
+}
+
+void reallocate_tt(U64 elements)
+{
+    TEntry* oldbuffer = TTable;
+    if ((TTable = (TEntry*)realloc(TTable, elements * sizeof(TEntry))) == NULL)
+    {
+        std::cout << "Error: Could not allocate memory for TT" << std::endl;
+        free(oldbuffer);
+        exit(1);
+    }
+
+    TT_SIZE = elements;  
+    std::memset(TTable, 0, TT_SIZE * sizeof(TEntry));    
 }

--- a/src/uci.h
+++ b/src/uci.h
@@ -5,6 +5,7 @@
 #include <atomic>
 #include <thread>
 #include <algorithm>
+#include <cstring>
 
 #include "board.h"
 #include "search.h"
@@ -19,3 +20,7 @@ std::vector<std::string> split_input(std::string fen);
 Move convert_uci_to_Move(std::string input);
 
 void stop_threads();
+
+void allocate_tt();
+
+void reallocate_tt(U64 elements);


### PR DESCRIPTION
Thank you @vondele for pointing out that the TT is not initialised after allocation/reallocation.
This is now fixed.

    ELO   | 9.65 +- 12.02 (95%)
    SPRT  | 4.0+0.04s Threads=1 Hash=8MB
    LLR   | 3.03 (-2.94, 2.94) [-10.00, 0.00]
    GAMES | N: 1872 W: 572 L: 520 D: 780

Bench: 2909386