### PR TITLE
performance patch

### DIFF
--- a/src/board.h
+++ b/src/board.h
@@ -48,6 +48,7 @@ struct States {
 
 struct Movelist {
 	Move list[MAX_MOVES]{};
+	int values[MAX_MOVES]{};
 	uint8_t size{};
 
 	void Add(Move move) {
@@ -76,8 +77,8 @@ public:
 	U64 pinD{};
 	uint8_t doubleCheck{};
 	U64 hashKey{};
-	U64 occWhite{};
-	U64 occBlack{};
+	U64 occUs;
+	U64 occEnemy;
 	U64 occAll{};
 	U64 enemyEmptyBB{};
 
@@ -185,6 +186,7 @@ public:
 
 	// Is square attacked by color c
 	bool isSquareAttacked(Color c, Square sq);
+	bool isSquareAttackedStatic(Color c, Square sq);
 	U64 allAttackers(Square sq, U64 occupiedBB);
 	U64 attackersForSide(Color attackerColor, Square sq, U64 occupiedBB);
 
@@ -213,6 +215,8 @@ public:
 	// plays the move on the internal board
 	void makeMove(Move& move);
 	void unmakeMove(Move& move);
+	void makeMovePerft(Move& move);
+	void unmakeMovePerft(Move& move);
 	void makeNullMove();
 	void unmakeNullMove();
 };

--- a/src/neuralnet.cpp
+++ b/src/neuralnet.cpp
@@ -63,11 +63,8 @@ void NNUE::init(const char* filename) {
 //     }
 // }
 
-int NNUE::relu(int x) {
-    if (x < 0) {
-        return 0;
-    }
-    return x;
+int16_t NNUE::relu(int16_t x) {
+    return std::max((int16_t)0, x);
 }
 
 int32_t NNUE::output(int16_t accumulator[HIDDEN_BIAS]) {

--- a/src/neuralnet.h
+++ b/src/neuralnet.h
@@ -26,7 +26,7 @@ extern int32_t outputBias[OUTPUT_BIAS];
 
 class NNUE {
     public:
-    int relu(int x);
+    int16_t relu(int16_t x);
     void init(const char* filename);
     // void accumulate(Board& b);
     // void activate(int inputNum);

--- a/src/perft.cpp
+++ b/src/perft.cpp
@@ -50,9 +50,9 @@ U64 Perft::perft_function(int depth, int max) {
     U64 nodesIt = 0;
     for (int i = 0; i < ml.size; i++) {
         Move move = ml.list[i];
-        board.makeMove(move);
+        board.makeMovePerft(move);
         nodesIt += perft_function(depth - 1, depth);
-        board.unmakeMove(move);
+        board.unmakeMovePerft(move);
         if (depth == max) {
             nodes += nodesIt;
             std::cout << board.printMove(move) << " " << nodesIt << std::endl;

--- a/src/search.h
+++ b/src/search.h
@@ -86,7 +86,6 @@ public:
     bool exit_early(uint64_t nodes, int ThreadId);
     uint64_t get_nodes();
 
-    void sortMoves(Movelist& moves);
     void sortMoves(Movelist& moves, int sorted);
 };
 

--- a/src/types.h
+++ b/src/types.h
@@ -231,58 +231,33 @@ static constexpr U64 PAWN_ATTACKS_TABLE[2][64] = {
       }
 };
 
-class Move {
-public:
-    uint16_t move;
-
-    // move score
-    int value;
-
-    // constructor for encoding a move
-    inline Move(
-        PieceType piece = NONETYPE,
-        Square source  = NO_SQ,
-        Square target  = NO_SQ,
-        bool promoted = false
-
-    ) {
-        move = (uint16_t)source | (uint16_t)target << 6 | (uint16_t)piece << 12 | (uint16_t)promoted << 15;
-    }
-
-    inline Square from() {
-        return Square(move & 0b111111);
-    }
-
-    inline Square to() {
-        return Square((move & 0b111111000000) >> 6);
-    }
-
-    inline PieceType piece() {
-        return PieceType((move & 0b111000000000000) >> 12);
-    }
-
-    inline bool promoted() {
-        return bool((move & 0b1000000000000000) >> 15);
-    }
-
-    inline uint16_t get() {
-        return move;
-    }
+enum Move : uint16_t {
+    NO_MOVE = 0,
+    NULL_MOVE = 65
 };
 
-static uint16_t NULLMOVE = Move(NONETYPE, NO_SQ, NO_SQ, false).get();
-static uint16_t NO_MOVE = Move(PAWN, SQ_A1, SQ_A1, false).get();
+inline Square from(Move move) {
+    return Square(move & 0b111111);
+}
+
+inline Square to(Move move) {
+    return Square((move & 0b111111000000) >> 6);
+}
+
+inline PieceType piece(Move move) {
+    return PieceType((move & 0b111000000000000) >> 12);
+}
+
+inline bool promoted(Move move) {
+    return bool((move & 0b1000000000000000) >> 15);
+}
+
+inline Move make(PieceType piece = NONETYPE, Square source = NO_SQ, Square target = NO_SQ, bool promoted = false) {
+    return Move((uint16_t)source | (uint16_t)target << 6 | (uint16_t)piece << 12 | (uint16_t)promoted << 15);
+}
 
 static constexpr U64 WK_CASTLE_MASK = (1ULL << SQ_F1) | (1ULL << SQ_G1);
 static constexpr U64 WQ_CASTLE_MASK = (1ULL << SQ_D1) | (1ULL << SQ_C1) | (1ULL << SQ_B1);
 
 static constexpr U64 BK_CASTLE_MASK = (1ULL << SQ_F8) | (1ULL << SQ_G8);
 static constexpr U64 BQ_CASTLE_MASK = (1ULL << SQ_D8) | (1ULL << SQ_C8) | (1ULL << SQ_B8);
-
-inline bool operator==(Move& m, Move& m2) {
-    return m.move == m2.move;
-}
-
-inline bool operator!=(Move& m, Move& m2) {
-    return m.move == m2.move;
-}

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -235,7 +235,6 @@ void signal_callback_handler(int signum) {
 }
 
 Move convert_uci_to_Move(std::string input) {
-    Move move;
     if (input.length() == 4) {
         std::string from = input.substr(0, 2);
         std::string to = input.substr(2);
@@ -252,7 +251,7 @@ Move convert_uci_to_Move(std::string input) {
         int to_index = (rank - 1) * 8 + file - 1;
         Square target = Square(to_index);
         PieceType piece = board.piece_type(board.pieceAtBB(source));
-        return Move(piece, source, target, false);
+        return make(piece, source, target, false);
     }
     if (input.length() == 5) {
         std::string from = input.substr(0, 2);
@@ -272,11 +271,11 @@ Move convert_uci_to_Move(std::string input) {
  
         char prom = input.at(4);
         PieceType piece = piece_to_int[prom];
-        return Move(piece, source, target, true);
+        return make(piece, source, target, true);
     }
     else {
         std::cout << "FALSE INPUT" << std::endl;
-        return Move(NONETYPE, NO_SQ, NO_SQ, false);
+        return make(NONETYPE, NO_SQ, NO_SQ, false);
     }
 }
 


### PR DESCRIPTION
Bench: 3031886

1. bench is different because i removed the different sort function for qsearch moves, i think it didnt even work properly... i also checked with master and removing this there also generated Bench: 3031886 so all is fine 
2. i removed the entire move class struct, instead moves are now just `enums : int16_t` 
3. assigning a score to a move is a bit scuffed since i use now two arrays one to hold the moves and another to hold the values... i could probably make this into making each entry a tuple (move, score)
4. perft is now a bit faster for those who care.. it has a different makemove function that doesnt update the accumulator but i kept the zobrist hashing.. why ? idk.
5. some other stuff is a bit optimized too, like no repeating calls to the same function in movegen
