### PR TITLE
transposition table in qsearch

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -69,7 +69,7 @@ Score Search::qsearch(int depth, Score alpha, Score beta, int ply, ThreadData *t
             }
         }
     }
-    if (!exit_early(td->nodes, td->id)) store_entry(depth, bestValue, oldAlpha, beta, td->board.hashKey, bestMove);
+    if (!exit_early(td->nodes, td->id)) store_entry(0, bestValue, oldAlpha, beta, td->board.hashKey, bestMove);
     return bestValue;
 }
 

--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -21,7 +21,7 @@ void store_entry(int depth, Score bestvalue,
     }
 }
 
-void probe_tt(TEntry &tte, bool &ttHit, U64 key, int depth)
+void probe_tt(TEntry &tte, bool &ttHit, U64 key)
 {
     U64 index = key % TT_SIZE;
     tte = TTable[index];

--- a/src/tt.h
+++ b/src/tt.h
@@ -16,4 +16,4 @@ void store_entry(int depth, Score bestvalue,
                  Score old_alpha, Score beta, U64 key,
                  uint16_t move);
 
-void probe_tt(TEntry &tte, bool &ttHit, U64 key, int depth);
+void probe_tt(TEntry &tte, bool &ttHit, U64 key);


### PR DESCRIPTION
    ELO   | 24.95 +- 10.91 (95%)
    SPRT  | 4.0+0.04s Threads=1 Hash=8MB
    LLR   | 2.99 (-2.94, 2.94) [0.00, 5.00]
    GAMES | N: 2176 W: 684 L: 528 D: 964

Bench: 2646759