### PR TITLE
finish last iterative depth search

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -853,7 +853,7 @@ bool Search::exitEarly(uint64_t nodes, int ThreadId)
     if (optimumTime != 0)
     {
         auto ms = getTime();
-        if (ms >= optimumTime || ms >= maxTime)
+        if (ms >= maxTime)
         {
             stopped = true;
             return true;

--- a/src/search.h
+++ b/src/search.h
@@ -98,7 +98,7 @@ class Search
   private:
     // Mainthread limits
     uint64_t maxNodes{};
-    int64_t searchTime{};
+    int64_t optimumTime{};
     int64_t maxTime{};
     int checkTime;
 

--- a/src/timemanager.cpp
+++ b/src/timemanager.cpp
@@ -27,7 +27,7 @@ Time optimumTime(int64_t avaiableTime, int inc, int ply, int mtg)
         time.optimum = (int64_t)std::max(1.0, avaiableTime / 20.0);
     }
 
-    time.maximum = (int64_t)(time.optimum * 1.05);
+    time.maximum = (int64_t)(time.optimum * 2);
     if (time.maximum >= avaiableTime)
     {
         time.maximum = time.optimum;


### PR DESCRIPTION
Changes in the time allocation so that an on going search can finish its last depth better.

ELO   | 21.31 +- 9.61 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 2416 W: 655 L: 507 D: 1254

Bench: 2882442