### PR TITLE
range based iterators for movelist

### DIFF
--- a/src/board.cpp
+++ b/src/board.cpp
@@ -917,7 +917,7 @@ void Board::removeCastlingRightsRook(Square sq)
     }
 }
 
-std::string uciMove(const Board &board, Move move)
+std::string uciMove(Move move, bool chess960)
 {
     std::stringstream ss;
 
@@ -927,7 +927,7 @@ std::string uciMove(const Board &board, Move move)
 
     // If the move is not a chess960 castling move and is a king moving more than one square,
     // update the to square to be the correct square for a regular castling move
-    if (!board.chess960 && piece(move) == KING && square_distance(to_sq, from_sq) >= 2)
+    if (!chess960 && piece(move) == KING && square_distance(to_sq, from_sq) >= 2)
     {
         to_sq = file_rank_square(to_sq > from_sq ? FILE_G : FILE_C, square_rank(from_sq));
     }

--- a/src/board.h
+++ b/src/board.h
@@ -540,7 +540,7 @@ template <bool updateNNUE> void Board::unmakeMove(Move move)
 /// @param board
 /// @param move
 /// @return
-std::string uciMove(const Board &board, Move move);
+std::string uciMove(Move move, bool chess960);
 
 Square extractSquare(std::string_view squareStr);
 

--- a/src/movegen.h
+++ b/src/movegen.h
@@ -4,10 +4,13 @@
 #include "helper.h"
 #include "types.h"
 
-PACK(struct ExtMove {
+#include <iterator>
+
+struct ExtMove
+{
     int value = 0;
     Move move = NO_MOVE;
-});
+};
 
 inline constexpr bool operator==(const ExtMove &a, const ExtMove &b)
 {
@@ -28,6 +31,8 @@ struct Movelist
 {
     ExtMove list[MAX_MOVES] = {};
     uint8_t size = 0;
+    typedef ExtMove *iterator;
+    typedef const ExtMove *const_iterator;
 
     void Add(Move move)
     {
@@ -49,6 +54,27 @@ struct Movelist
                 return i;
         }
         return -1;
+    }
+
+    iterator begin()
+    {
+        return (std::begin(list));
+    }
+    const_iterator begin() const
+    {
+        return (std::begin(list));
+    }
+    iterator end()
+    {
+        auto it = std::begin(list);
+        std::advance(it, size);
+        return it;
+    }
+    const_iterator end() const
+    {
+        auto it = std::begin(list);
+        std::advance(it, size);
+        return it;
     }
 };
 

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -57,6 +57,7 @@ template <SearchType st> template <bool score> Move MovePick<st>::orderNext()
         if (movelist[i] > movelist[index])
             index = i;
     }
+
     std::swap(movelist[index], movelist[played]);
 
     return movelist[played++].move;

--- a/src/perft.cpp
+++ b/src/perft.cpp
@@ -13,9 +13,9 @@ U64 Perft::perftFunction(int depth, int max)
         return movelists[depth].size;
     }
     U64 nodesIt = 0;
-    for (int i = 0; i < movelists[depth].size; i++)
+    for (auto extmove : movelists[depth])
     {
-        Move move = movelists[depth][i].move;
+        Move move = extmove.move;
         board.makeMove<false>(move);
         nodesIt += perftFunction(depth - 1, depth);
         board.unmakeMove<false>(move);

--- a/src/perft.cpp
+++ b/src/perft.cpp
@@ -22,7 +22,7 @@ U64 Perft::perftFunction(int depth, int max)
         if (depth == max)
         {
             nodes += nodesIt;
-            std::cout << uciMove(board, move) << " " << nodesIt << std::endl;
+            std::cout << uciMove(move, board.chess960) << " " << nodesIt << std::endl;
             nodesIt = 0;
         }
     }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -450,8 +450,8 @@ moves:
          * Print currmove information.
          *******************/
         if (id == 0 && RootNode && normalSearch && !stopped.load(std::memory_order_relaxed) && getTime() > 10000)
-            std::cout << "info depth " << depth - inCheck << " currmove " << uciMove(board, move) << " currmovenumber "
-                      << signed(madeMoves) << std::endl;
+            std::cout << "info depth " << depth - inCheck << " currmove " << uciMove(move, board.chess960)
+                      << " currmovenumber " << signed(madeMoves) << std::endl;
 
         /********************
          * Play the move on the internal board.
@@ -724,7 +724,7 @@ SearchResult Search::iterativeDeepening()
      *******************/
     if (id == 0 && normalSearch)
     {
-        std::cout << "bestmove " << uciMove(board, bestmove) << std::endl;
+        std::cout << "bestmove " << uciMove(bestmove, board.chess960) << std::endl;
         stopped = true;
     }
 
@@ -754,7 +754,7 @@ void Search::startThinking()
         Move dtzMove = probeDTZ();
         if (dtzMove != NO_MOVE)
         {
-            std::cout << "bestmove " << uciMove(board, dtzMove) << std::endl;
+            std::cout << "bestmove " << uciMove(dtzMove, board.chess960) << std::endl;
             stopped = true;
             return;
         }
@@ -799,7 +799,7 @@ std::string Search::getPV()
 
     for (int i = 0; i < pvLength[0]; i++)
     {
-        ss << " " << uciMove(board, pvTable[0][i]);
+        ss << " " << uciMove(pvTable[0][i], board.chess960);
     }
 
     return ss.str();
@@ -902,7 +902,7 @@ Move Search::probeDTZ()
                 (promo < 5 && promoTranslation[promo] == piece(move) && promoted(move)))
             {
                 uciOutput(s, static_cast<int>(dtz), 1, Threads.getNodes(), Threads.getTbHits(), getTime(),
-                          " " + uciMove(board, move), TTable.hashfull());
+                          " " + uciMove(move, board.chess960), TTable.hashfull());
                 return move;
             }
         }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -42,9 +42,9 @@ template <Movetype type> void Search::updateHistory(Move bestmove, int bonus, in
     if (depth > 1)
         updateHistoryBonus<type>(bestmove, bonus);
 
-    for (int i = 0; i < movelist.size; i++)
+    for (auto ext : movelist)
     {
-        const Move move = movelist[i].move;
+        const Move move = ext.move;
         if (move == bestmove)
             continue;
 
@@ -893,9 +893,9 @@ Move Search::probeDTZ()
     Movelist legalmoves;
     Movegen::legalmoves<Movetype::ALL>(board, legalmoves);
 
-    for (int i = 0; i < legalmoves.size; i++)
+    for (auto ext : legalmoves)
     {
-        Move move = legalmoves[i].move;
+        const Move move = ext.move;
         if (from(move) == sqFrom && to(move) == sqTo)
         {
             if ((promoTranslation[promo] == NONETYPE && !promoted(move)) ||
@@ -907,6 +907,7 @@ Move Search::probeDTZ()
             }
         }
     }
+
     std::cout << " something went wrong playing dtz :" << promoTranslation[promo] << " : " << promo << " : "
               << std::endl;
     exit(0);

--- a/src/tests/testMoveLegality.h
+++ b/src/tests/testMoveLegality.h
@@ -1,13 +1,6 @@
 #pragma once
 
 #include "tests.h"
-std::string infoMove(Move move)
-{
-    std::stringstream ss;
-    ss << "Promoted: " << int(promoted(move)) << " Piece: " << int(piece(move)) << " from: " << int(from(move))
-       << " to: " << int(to(move)) << std::endl;
-    return ss.str();
-}
 
 bool testIsPseudoLegalAndIsLegal(const std::string &fen)
 {
@@ -23,12 +16,12 @@ bool testIsPseudoLegalAndIsLegal(const std::string &fen)
 
         if (moves.find(m) == -1 && (b.isPseudoLegal(m) && b.isLegal(m)))
         {
-            std::cout << infoMove(m) << uciMove(b, m) << std::endl;
+            std::cout << m << uciMove(m, b.chess960) << std::endl;
             return false;
         }
         else if (moves.find(m) >= 0 && !(b.isPseudoLegal(m) && b.isLegal(m)))
         {
-            std::cout << infoMove(m) << uciMove(b, m) << std::endl;
+            std::cout << m << uciMove(m, b.chess960) << std::endl;
             return false;
         }
     }

--- a/src/tests/testMoveLegality.h
+++ b/src/tests/testMoveLegality.h
@@ -52,7 +52,8 @@ void testAllMoveLegality()
                                       "4kbnr/5ppp/4p3/1R1pnb2/8/6P1/5P1P/2B1K2R b Kk - 0 20",
                                       "3r2k1/2r2ppp/p3p1b1/B2p4/3NnP2/P7/6PP/4QR1K b - - 2 25"
                                       "4nk2/pp1r1pp1/4b2n/1Pp5/P1P3PB/5N1P/8/KB2R3 w - - 3 38",
-                                      "3n4/5k2/6p1/1P1b2P1/P7/2K5/8/4R3 b - - 2 52"};
+                                      "3n4/5k2/6p1/1P1b2P1/P7/2K5/8/4R3 b - - 2 52",
+                                      "r1bqk1r1/1p1p1n2/p1n2pN1/2p1b2Q/2P1Pp2/1PN5/PB4PP/R4RK1 w q - 0 1"};
 
     std::vector<std::string> tests960 = {DEFAULT_POS,
                                          "1rqbkrbn/1ppppp1p/1n6/p1N3p1/8/2P4P/PP1PPPP1/1RQBKRBN w FBfb - 0 9",

--- a/src/types.h
+++ b/src/types.h
@@ -442,3 +442,15 @@ template <PieceType piece, bool promoted> Move make(Square source = NO_SQ, Squar
 {
     return Move((uint16_t)source | (uint16_t)target << 6 | (uint16_t)piece << 12 | (uint16_t)promoted << 15);
 }
+
+inline std::ostream &operator<<(std::ostream &os, const Move move)
+{
+    // clang-format off
+    os << " From: "    << int(from(move)) 
+       << " To: "      << int(to(move)) 
+       << " Piece: "   << int(piece(move))
+       << "Promoted: " << int(promoted(move));
+    // clang-format on
+    os << std::endl;
+    return os;
+}

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -168,7 +168,7 @@ void UCI::processCommand(std::string command)
         Movegen::legalmoves<Movetype::CAPTURE>(board, moves);
 
         for (auto ext : moves)
-            std::cout << uciMove(board, ext.move) << std::endl;
+            std::cout << uciMove(ext.move, board.chess960) << std::endl;
 
         std::cout << "count: " << signed(moves.size) << std::endl;
     }
@@ -178,7 +178,7 @@ void UCI::processCommand(std::string command)
         Movegen::legalmoves<Movetype::ALL>(board, moves);
 
         for (auto ext : moves)
-            std::cout << uciMove(board, ext.move) << std::endl;
+            std::cout << uciMove(ext.move, board.chess960) << std::endl;
 
         std::cout << "count: " << signed(moves.size) << std::endl;
     }

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -167,8 +167,8 @@ void UCI::processCommand(std::string command)
         Movelist moves;
         Movegen::legalmoves<Movetype::CAPTURE>(board, moves);
 
-        for (int i = 0; i < moves.size; i++)
-            std::cout << uciMove(board, moves[i].move) << std::endl;
+        for (auto ext : moves)
+            std::cout << uciMove(board, ext.move) << std::endl;
 
         std::cout << "count: " << signed(moves.size) << std::endl;
     }
@@ -177,8 +177,8 @@ void UCI::processCommand(std::string command)
         Movelist moves;
         Movegen::legalmoves<Movetype::ALL>(board, moves);
 
-        for (int i = 0; i < moves.size; i++)
-            std::cout << uciMove(board, moves[i].move) << std::endl;
+        for (auto ext : moves)
+            std::cout << uciMove(board, ext.move) << std::endl;
 
         std::cout << "count: " << signed(moves.size) << std::endl;
     }


### PR DESCRIPTION
introduce support of the following syntax

```cpp
Movelist moves;
Movegen::legalmoves<Movetype::ALL>(board, moves);
for (auto ext : moves)
   std::cout << ext.move << std::
```

and overload ostream << for move type

Bench: 2795524