### PR TITLE
increase time when losing

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -739,6 +739,7 @@ SearchResult Search::iterativeDeepening()
      *******************/
     for (depth = 1; depth <= limit.depth; depth++)
     {
+        int previousResult = result;
         seldepth = 0;
         result = aspirationSearch(depth, result, ss);
         evalAverage += result;
@@ -768,6 +769,9 @@ SearchResult Search::iterativeDeepening()
                 break;
 
             if (result + 30 < evalAverage / depth)
+                limit.time.optimum *= 1.10;
+
+            if (result - previousResult < -20)
                 limit.time.optimum *= 1.10;
 
             // stop if we have searched for more than 75% of our max time.

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -768,10 +768,10 @@ SearchResult Search::iterativeDeepening()
             if (depth > 10 && limit.time.optimum * (110 - std::min(effort, 90)) / 100 < now)
                 break;
 
-            if (result > -200 && result + 30 < evalAverage / depth)
+            if (result + 30 < evalAverage / depth)
                 limit.time.optimum *= 1.10;
 
-            if (result - previousResult < -20)
+            if (result > -200 && result - previousResult < -20)
                 limit.time.optimum *= 1.10;
 
             // stop if we have searched for more than 75% of our max time.

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -768,7 +768,7 @@ SearchResult Search::iterativeDeepening()
             if (depth > 10 && limit.time.optimum * (110 - std::min(effort, 90)) / 100 < now)
                 break;
 
-            if (result + 30 < evalAverage / depth)
+            if (result > -200 && result + 30 < evalAverage / depth)
                 limit.time.optimum *= 1.10;
 
             if (result - previousResult < -20)


### PR DESCRIPTION
Thanks to Zuppa for letting me use Smallbrain on his OB instance.

The version of this patch without `result > -200` passed there, 
however I think the limiting factor is preventing excessive time usage in really lost positions and should still be an elo gainer.
```
ELO   | 5.03 +- 3.81 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 13536 W: 2970 L: 2774 D: 7792
```

Bench: 3729977